### PR TITLE
Fix plugin configuration and D3 chart margin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
-gem "just-the-docs"
+gem "just-the-docs", group: :jekyll_plugins

--- a/projectes.md
+++ b/projectes.md
@@ -27,7 +27,7 @@ Aquí trobareu els projectes desenvolupats pels alumnes.
     .data(dades)
     .enter()
     .append("rect")
-    .attr("x", (d, i) => i * (amplada / dades.length))
+    .attr("x", (d, i) => i * (amplada / dades.length) + marge / 2)
     .attr("y", d => alçada - d)
     .attr("width", amplada / dades.length - marge)
     .attr("height", d => d)


### PR DESCRIPTION
## Summary
- ensure `just-the-docs` gem is loaded as a Jekyll plugin
- offset D3 bar chart by half-margin so bars don't touch edges

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a347663cac832390f92a015351dacb