### PR TITLE
Add next-piece preview and unicorn explosion to Tetris

### DIFF
--- a/tetris.md
+++ b/tetris.md
@@ -7,5 +7,8 @@ nav_order: 6
 
 Utilitza les fletxes del teclat per moure les peces i forma línies completes.
 
-<canvas id="tetris" width="200" height="400" style="border:1px solid #ccc"></canvas>
+<div style="display:flex; gap:10px;">
+  <canvas id="tetris" width="200" height="400" style="border:1px solid #ccc"></canvas>
+  <canvas id="next" width="80" height="80" style="border:1px solid #ccc"></canvas>
+</div>
 <script defer src="{{ '/assets/js/tetris.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- Display upcoming Tetris piece alongside the board
- Introduce a rare unicorn piece that explodes adjacent blocks

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd48e71083239a52d40c65b2b291